### PR TITLE
Add default reading time calculation (2 minutes per page)

### DIFF
--- a/Books83/Views/ReadingLogs/QuickLogSheet.swift
+++ b/Books83/Views/ReadingLogs/QuickLogSheet.swift
@@ -95,7 +95,15 @@ struct QuickLogSheet: View {
         guard let book = selectedBook,
               let pages = Int(pagesRead), pages > 0 else { return }
         
-        let timeToLog = trackTime ? Int(readingMinutes) : nil
+        // Calculate reading time: use tracked time or estimate 2 minutes per page
+        let timeToLog: Int?
+        if trackTime {
+            timeToLog = Int(readingMinutes)
+        } else {
+            // Default: 2 minutes per page
+            timeToLog = pages * 2
+        }
+        
         let log = ReadingLog(
             book: book,
             pagesRead: pages,
@@ -103,7 +111,27 @@ struct QuickLogSheet: View {
             notes: notes.isEmpty ? nil : notes
         )
         
+        // Update book progress and status
+        let oldCurrentPage = book.currentPage
+        let newCurrentPage = min(book.currentPage + pages, book.totalPages)
+        book.currentPage = newCurrentPage
+        
+        // Update status based on progress
+        if newCurrentPage >= book.totalPages {
+            book.status = .completed
+        } else if book.status == .toRead {
+            book.status = .reading
+        }
+        
         modelContext.insert(log)
+        
+        // Save changes to ensure persistence
+        do {
+            try modelContext.save()
+        } catch {
+            print("Failed to save context: \(error)")
+        }
+        
         dismiss()
     }
 }


### PR DESCRIPTION
FEATURE: Implement automatic reading time estimation

📖 Reading Time Features:
- Default calculation: 2 minutes per page when time tracking is disabled
- Manual time tracking option still available for precise logging
- Automatic book progress and status updates
- Enhanced data persistence with error handling

🔧 Technical Details:
- Updated saveReading() method in QuickLogSheet
- Smart time calculation: manual tracking takes priority over estimation
- Book status automatically updates (toRead -> reading -> completed)
- Proper SwiftData context saving with error handling

📊 User Experience:
- No manual time entry required for casual reading logs
- Reasonable default estimation for reading analytics
- Maintains existing manual time tracking functionality
- Seamless book progress tracking

This provides a balanced approach between convenience and accuracy for reading time tracking.